### PR TITLE
changelog / re-exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This project follows semantic versioning.
+
+### 0.5.0 (2015-12-02)
+- `[added]` This change log!
+- `[changed]` Use typenum instead of peano for faster and more complete type-level numbers. (#3)
+- `[added]` Re-export useful things from typenum so that crates downstream don't need to depend on it.
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
   name = "dimensioned"
-  version = "0.4.0"
+  version = "0.5.0"
   authors = ["Paho Lurie-Gregg <paho@paholg.com>"]
   description = "Compile-time type checking of arbitrary unit systems."
   homepage = "http://paholg.com/project/dimensioned"

--- a/src/dimensioned.rs
+++ b/src/dimensioned.rs
@@ -6,11 +6,9 @@ many traits from `std` as generically as possible.
 Among the included traits in **dimensioned**, there are a few that are used solely to
 aid in generic programming and should not be implemented for anything outside this
 module. They are `Dimension`, `Dimensionless`, and `DimToString`.
-*/
+ */
 
-use typenum::Same;
-use typenum::int::Integer;
-use typenum::consts::{P2, P3};
+use {Same, Integer, P2, P3};
 
 use std::marker::PhantomData;
 
@@ -140,16 +138,12 @@ pub trait Cbrt {
     Take a cube root.
     # Example
     ```
-    # extern crate typenum;
-    # extern crate dimensioned;
     use dimensioned::si::m;
     use dimensioned::Cbrt;
 
-    # fn main() {
     let x = 2.0*m;
     let y = 8.0*m*m*m;
     assert_eq!(x, y.cbrt());
-    # }
     ```
      */
     fn cbrt(self) -> Self::Output;
@@ -176,18 +170,13 @@ pub trait Root<Radicand> {
     /**
     # Example
     ```
-    # extern crate typenum;
-    # extern crate dimensioned;
-
     use dimensioned::si::m;
     use dimensioned::Root;
-    use typenum::consts::P4;
+    use dimensioned::P4;
 
-    # fn main() {
     let x = 2.0*m;
     let y = 16.0*m*m*m*m;
     assert_eq!(x, P4::root(x*x*x*x));
-    # }
     ```
     */
     fn root(radicand: Radicand) -> Self::Output;
@@ -214,18 +203,13 @@ pub trait Pow<Base> {
     /**
     # Example
     ```
-    # extern crate typenum;
-    # extern crate dimensioned;
-
     use dimensioned::si::m;
     use dimensioned::Pow;
-    use typenum::consts::P3;
+    use dimensioned::P3;
 
-    # fn main() {
     let x = 2.0*m;
     let y = 8.0*m*m*m;
     assert_eq!(P3::pow(x), y);
-    # }
     ```
     */
     fn pow(base: Base) -> Self::Output;
@@ -292,11 +276,10 @@ Note: This macro requires that `Dim` and `Dimension` be imported.
 
 # Example
 ```rust
-extern crate typenum;
 #[macro_use]
 extern crate dimensioned;
 
-use typenum::Same;
+use dimensioned::Same;
 use dimensioned::{Dim, Dimension};
 use dimensioned::si::m;
 use std::ops::Mul;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@ For in depth tutorials, check [here](http://paholg.com/project/dimensioned).
 extern crate typenum;
 extern crate num;
 
+pub use typenum::Same;
+pub use typenum::int::Integer;
+pub use typenum::consts::{N9, N8, N7, N6, N5, N4, N3, N2, N1, Z0, P1, P2, P3, P4, P5, P6, P7, P8, P9};
 
 pub use dimensioned::*;
 

--- a/src/make_units.rs
+++ b/src/make_units.rs
@@ -8,7 +8,6 @@ Note that it has some imports from the peano crate, so it must be included.
 
 # Example
 ```rust
-extern crate typenum;
 #[macro_use]
 extern crate dimensioned;
 
@@ -79,7 +78,6 @@ inside of its own module.
 Here we define the **CGS** unit system.
 
 ```rust
-extern crate typenum;
 #[macro_use]
 extern crate dimensioned;
 
@@ -130,8 +128,8 @@ macro_rules! make_units_adv {
          $($derived_constant:ident: $Derived:ident = $e:expr;)*
      } ) => (
         #[allow(unused_imports)]
-        use typenum::consts::{Z0, P1, P2, P3, P4, P5, P6, P7, P8, P9, N1, N2, N3, N4, N5, N6, N7, N8, N9};
-        use typenum::int::Integer;
+        use $crate::{Z0, P1, P2, P3, P4, P5, P6, P7, P8, P9, N1, N2, N3, N4, N5, N6, N7, N8, N9};
+        use $crate::Integer;
         use $crate::{Dimension, Dimensionless, Dim, Pow, Root, Recip, DimToString};
         use ::std::ops::{Add, Neg, Sub, Mul, Div};
         use ::std::marker::PhantomData;


### PR DESCRIPTION
I've added a changelog and added re-exports of the useful things from typenum. I think this will make it easier to use dimensioned, as downstream crates won't have to depend on typenum.
